### PR TITLE
Add optional default guild ID support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,14 @@ The Discord MPC server can be configured by adding the following to your configu
         "/absolute/path/to/discord-mcp-0.0.1-SNAPSHOT.jar"
       ],
       "env": {
-        "DISCORD_TOKEN": "YOUR_DISCORD_BOT_TOKEN"
+        "DISCORD_TOKEN": "YOUR_DISCORD_BOT_TOKEN",
+        "DISCORD_GUILD_ID": "OPTIONAL_DEFAULT_SERVER_ID"
       }
     }
   }
 }
 ```
+The `DISCORD_GUILD_ID` environment variable is optional. When provided, it sets a default Discord server ID so tool calls don't require the `guildId` parameter.
 
 
 ## 🔧 GitMCP
@@ -77,12 +79,14 @@ Use Discord MCP remotely via [GitMCP](https://gitmcp.io/):
         "https://gitmcp.io/SaseQ/discord-mcp"
       ],
       "env": {
-        "DISCORD_TOKEN": "YOUR_DISCORD_BOT_TOKEN"
+        "DISCORD_TOKEN": "YOUR_DISCORD_BOT_TOKEN",
+        "DISCORD_GUILD_ID": "OPTIONAL_DEFAULT_SERVER_ID"
       }
     }
   }
 }
 ```
+Set `DISCORD_GUILD_ID` here as well if you want to automatically target a specific server.
 More info and different configs [here](https://gitmcp.io/SaseQ/discord-mcp)
 
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The Discord MPC server can be configured by adding the following to your configu
   }
 }
 ```
-The `DISCORD_GUILD_ID` environment variable is optional. When provided, it sets a default Discord server ID so tool calls don't require the `guildId` parameter.
+The `DISCORD_GUILD_ID` environment variable is optional. When provided, it sets a default Discord server ID so any tool that accepts a `guildId` parameter can omit it.
 
 
 ## 🔧 GitMCP
@@ -99,6 +99,8 @@ npx -y @smithery/cli@latest install @SaseQ/discord-mcp --client claude
 
 
 ## 🛠️ Available Tools
+
+If `DISCORD_GUILD_ID` is set, the `guildId` parameter becomes optional for all tools below.
 
 #### Server Information
  - [`get_server_info`](): Get detailed discord server information

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -9,6 +9,9 @@ startCommand:
       discordToken:
         type: string
         description: The bot token for Discord integration.
+      discordGuildId:
+        type: string
+        description: Optional default Discord server ID.
   commandFunction:
     |-
-    config => ({command: 'java', args: ['-jar', './target/discord-mcp-0.0.1-SNAPSHOT.jar'], env: {DISCORD_TOKEN: config.discordToken}})
+    config => ({command: 'java', args: ['-jar', './target/discord-mcp-0.0.1-SNAPSHOT.jar'], env: {DISCORD_TOKEN: config.discordToken, DISCORD_GUILD_ID: config.discordGuildId}})

--- a/src/main/java/dev/saseq/services/DiscordService.java
+++ b/src/main/java/dev/saseq/services/DiscordService.java
@@ -8,6 +8,7 @@ import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.Collections;
@@ -18,13 +19,23 @@ import java.util.stream.Collectors;
 @Service
 public class DiscordService {
     private final JDA jda;
+    @Value("${DISCORD_GUILD_ID:}")
+    private String defaultGuildId;
 
     public DiscordService(JDA jda) {
         this.jda = jda;
     }
 
+    private String resolveGuildId(String guildId) {
+        if ((guildId == null || guildId.isEmpty()) && defaultGuildId != null && !defaultGuildId.isEmpty()) {
+            return defaultGuildId;
+        }
+        return guildId;
+    }
+
     @Tool(name = "get_server_info", description = "Get detailed discord server information")
     public String getServerInfo(@ToolParam(description = "Discord server ID") String guildId) {
+        guildId = resolveGuildId(guildId);
         if (guildId == null || guildId.isEmpty()) {
             throw new IllegalArgumentException("Discord server ID cannot be null");
         }
@@ -306,6 +317,7 @@ public class DiscordService {
     @Tool(name = "delete_channel", description = "Delete a channel")
     public String deleteChannel(@ToolParam(description = "Discord server ID") String guildId,
                                 @ToolParam(description = "Discord server ID") String channelId) {
+        guildId = resolveGuildId(guildId);
         if (guildId == null || guildId.isEmpty()) {
             throw new IllegalArgumentException("guildId cannot be null");
         }
@@ -329,6 +341,7 @@ public class DiscordService {
     public String createTextChannel(@ToolParam(description = "Discord server ID") String guildId,
                                     @ToolParam(description = "Channel name") String name,
                                     @ToolParam(description = "Category ID (optional)", required = false) String categoryId) {
+        guildId = resolveGuildId(guildId);
         if (guildId == null || guildId.isEmpty()) {
             throw new IllegalArgumentException("guildId cannot be null");
         }
@@ -358,6 +371,7 @@ public class DiscordService {
     @Tool(name = "find_channel", description = "Find a channel type and ID using name and server ID")
     public String findChannel(@ToolParam(description = "Discord server ID") String guildId,
                               @ToolParam(description = "Discord category name") String channelName) {
+        guildId = resolveGuildId(guildId);
         if (guildId == null || guildId.isEmpty()) {
             throw new IllegalArgumentException("guildId cannot be null");
         }
@@ -389,6 +403,7 @@ public class DiscordService {
 
     @Tool(name = "list_channels", description = "List of all channels")
     public String listChannels(@ToolParam(description = "Discord server ID") String guildId) {
+        guildId = resolveGuildId(guildId);
         if (guildId == null || guildId.isEmpty()) {
             throw new IllegalArgumentException("guildId cannot be null");
         }
@@ -410,6 +425,7 @@ public class DiscordService {
     @Tool(name = "create_category", description = "Create a new category for channels")
     public String createCategory(@ToolParam(description = "Discord server ID") String guildId,
                                  @ToolParam(description = "Discord category name") String name) {
+        guildId = resolveGuildId(guildId);
         if (guildId == null || guildId.isEmpty()) {
             throw new IllegalArgumentException("guildId cannot be null");
         }
@@ -428,6 +444,7 @@ public class DiscordService {
     @Tool(name = "delete_category", description = "Delete a category")
     public String deleteCategory(@ToolParam(description = "Discord server ID") String guildId,
                                @ToolParam(description = "Discord category ID") String categoryId) {
+        guildId = resolveGuildId(guildId);
         if (guildId == null || guildId.isEmpty()) {
             throw new IllegalArgumentException("guildId cannot be null");
         }
@@ -450,6 +467,7 @@ public class DiscordService {
     @Tool(name = "find_category", description = "Find a category ID using name and server ID")
     public String findCategory(@ToolParam(description = "Discord server ID") String guildId,
                                @ToolParam(description = "Discord category name") String categoryName) {
+        guildId = resolveGuildId(guildId);
         if (guildId == null || guildId.isEmpty()) {
             throw new IllegalArgumentException("guildId cannot be null");
         }
@@ -479,6 +497,7 @@ public class DiscordService {
     @Tool(name = "list_channels_in_category", description = "List of channels in a specific category")
     public String listChannelsInCategory(@ToolParam(description = "Discord server ID") String guildId,
                                          @ToolParam(description = "Discord category ID") String categoryId) {
+        guildId = resolveGuildId(guildId);
         if (guildId == null || guildId.isEmpty()) {
             throw new IllegalArgumentException("guildId cannot be null");
         }

--- a/src/main/java/dev/saseq/services/DiscordService.java
+++ b/src/main/java/dev/saseq/services/DiscordService.java
@@ -34,7 +34,7 @@ public class DiscordService {
     }
 
     @Tool(name = "get_server_info", description = "Get detailed discord server information")
-    public String getServerInfo(@ToolParam(description = "Discord server ID") String guildId) {
+    public String getServerInfo(@ToolParam(description = "Discord server ID", required = false) String guildId) {
         guildId = resolveGuildId(guildId);
         if (guildId == null || guildId.isEmpty()) {
             throw new IllegalArgumentException("Discord server ID cannot be null");
@@ -315,8 +315,8 @@ public class DiscordService {
     }
 
     @Tool(name = "delete_channel", description = "Delete a channel")
-    public String deleteChannel(@ToolParam(description = "Discord server ID") String guildId,
-                                @ToolParam(description = "Discord server ID") String channelId) {
+    public String deleteChannel(@ToolParam(description = "Discord server ID", required = false) String guildId,
+                                @ToolParam(description = "Discord channel ID") String channelId) {
         guildId = resolveGuildId(guildId);
         if (guildId == null || guildId.isEmpty()) {
             throw new IllegalArgumentException("guildId cannot be null");
@@ -338,7 +338,7 @@ public class DiscordService {
     }
 
     @Tool(name = "create_text_channel", description = "Create a new text channel")
-    public String createTextChannel(@ToolParam(description = "Discord server ID") String guildId,
+    public String createTextChannel(@ToolParam(description = "Discord server ID", required = false) String guildId,
                                     @ToolParam(description = "Channel name") String name,
                                     @ToolParam(description = "Category ID (optional)", required = false) String categoryId) {
         guildId = resolveGuildId(guildId);
@@ -369,7 +369,7 @@ public class DiscordService {
     }
 
     @Tool(name = "find_channel", description = "Find a channel type and ID using name and server ID")
-    public String findChannel(@ToolParam(description = "Discord server ID") String guildId,
+    public String findChannel(@ToolParam(description = "Discord server ID", required = false) String guildId,
                               @ToolParam(description = "Discord category name") String channelName) {
         guildId = resolveGuildId(guildId);
         if (guildId == null || guildId.isEmpty()) {
@@ -402,7 +402,7 @@ public class DiscordService {
     }
 
     @Tool(name = "list_channels", description = "List of all channels")
-    public String listChannels(@ToolParam(description = "Discord server ID") String guildId) {
+    public String listChannels(@ToolParam(description = "Discord server ID", required = false) String guildId) {
         guildId = resolveGuildId(guildId);
         if (guildId == null || guildId.isEmpty()) {
             throw new IllegalArgumentException("guildId cannot be null");
@@ -423,7 +423,7 @@ public class DiscordService {
     }
 
     @Tool(name = "create_category", description = "Create a new category for channels")
-    public String createCategory(@ToolParam(description = "Discord server ID") String guildId,
+    public String createCategory(@ToolParam(description = "Discord server ID", required = false) String guildId,
                                  @ToolParam(description = "Discord category name") String name) {
         guildId = resolveGuildId(guildId);
         if (guildId == null || guildId.isEmpty()) {
@@ -442,7 +442,7 @@ public class DiscordService {
     }
 
     @Tool(name = "delete_category", description = "Delete a category")
-    public String deleteCategory(@ToolParam(description = "Discord server ID") String guildId,
+    public String deleteCategory(@ToolParam(description = "Discord server ID", required = false) String guildId,
                                @ToolParam(description = "Discord category ID") String categoryId) {
         guildId = resolveGuildId(guildId);
         if (guildId == null || guildId.isEmpty()) {
@@ -465,7 +465,7 @@ public class DiscordService {
     }
 
     @Tool(name = "find_category", description = "Find a category ID using name and server ID")
-    public String findCategory(@ToolParam(description = "Discord server ID") String guildId,
+    public String findCategory(@ToolParam(description = "Discord server ID", required = false) String guildId,
                                @ToolParam(description = "Discord category name") String categoryName) {
         guildId = resolveGuildId(guildId);
         if (guildId == null || guildId.isEmpty()) {
@@ -495,7 +495,7 @@ public class DiscordService {
     }
 
     @Tool(name = "list_channels_in_category", description = "List of channels in a specific category")
-    public String listChannelsInCategory(@ToolParam(description = "Discord server ID") String guildId,
+    public String listChannelsInCategory(@ToolParam(description = "Discord server ID", required = false) String guildId,
                                          @ToolParam(description = "Discord category ID") String categoryId) {
         guildId = resolveGuildId(guildId);
         if (guildId == null || guildId.isEmpty()) {


### PR DESCRIPTION
## Summary
- allow setting `DISCORD_GUILD_ID` environment variable
- use the value as default server ID in DiscordService
- document the new env variable in README
- expose optional guild ID in `smithery.yaml`

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856045b1bd083288f83f3c459f20cf7